### PR TITLE
adds a simple example to demonstrate usage

### DIFF
--- a/bigquery/bqiface/doc.go
+++ b/bigquery/bqiface/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bqiface provides a set of interfaces for the types in
+// cloud.google.com/go/bigquery. These can be used to create mocks or other
+// test doubles. The package also provides adapters to enable the types of the
+// bigquery package to implement these interfaces.
+//
+// We do not recommend using mocks for most testing. Please read
+// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+//
+// Note: This package is in alpha. Some backwards-incompatible changes may occur.
+//
+// You must embed these interfaces to implement them:
+//
+//    type ClientMock struct {
+//        bqiface.Client
+//        ...
+//    }
+//
+// This ensures that your implementations will not break when methods are added to the interfaces.
+package bqiface

--- a/bigquery/bqiface/examples_test.go
+++ b/bigquery/bqiface/examples_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/bigquery/bqiface"
 	"github.com/googleapis/google-cloud-go-testing/bigquery/bqiface"
 )
 

--- a/bigquery/bqiface/interfaces.go
+++ b/bigquery/bqiface/interfaces.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package bqiface provides a set of interfaces for the types in cloud.google.com/go/bigquery.
-// These can be used to create mocks or other test doubles.
-// The package also provides adapters to enable the types of the bigquery package to
-// implement these interfaces.
-//
-// We do not recommend using mocks for most testing. Please read
-// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
-//
-// You must embed these interfaces to implement them:
-//
-//    type ClientMock struct {
-//        bqiface.Client
-//        ...
-//    }
-//
-// This ensures that your implementations will not break when methods are added to the interfaces.
 package bqiface
 
 import (

--- a/datastore/dsiface/doc.go
+++ b/datastore/dsiface/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dsiface provides a set of interfaces for the types in
+// cloud.google.com/go/datastore. These can be used to create mocks or other
+// test doubles. The package also provides adapters to enable the types of the
+// datastore package to implement these interfaces.
+//
+// We do not recommend using mocks for most testing. Please read
+// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+//
+// Note: This package is in alpha. Some backwards-incompatible changes may occur.
+//
+// You must embed these interfaces to implement them:
+//
+//    type ClientMock struct {
+//        dsiface.Client
+//        ...
+//    }
+//
+// This ensures that your implementations will not break when methods are added
+// to the interfaces.
+package dsiface

--- a/datastore/dsiface/interfaces.go
+++ b/datastore/dsiface/interfaces.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package dsiface provides a set of interfaces for the types in cloud.google.com/go/datastore
-// These can be used to create mocks or other test doubles.
-// The package also provides adapters to enable the types of the datastore package to
-// implement these interfaces.
-//
-// We do not recommend using mocks for most testing. Please read
-// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
-//
-// You must embed these interfaces to implement them:
-//
-//    type ClientMock struct {
-//        dsiface.Client
-//        ...
-//    }
-//
-// This ensures that your implementations will not break when methods are added to the interfaces.
 package dsiface
 
 import (

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+These packages contain code that can help you test against the GCP Client
+Libraries for Go (https://github.com/GoogleCloudPlatform/google-cloud-go).
+
+We do not recommend using mocks for most testing. Please read
+https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+
+Note: These packages are in alpha. Some backwards-incompatible changes may
+occur.
+*/
+package googlecloudgotesting
+

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,0 +1,42 @@
+package googlecloudgotesting
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/storage"
+	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
+)
+
+type RecordingClient struct {
+	stiface.Client
+	bucketCalls int
+}
+
+func (rc *RecordingClient) Bucket(name string) stiface.BucketHandle {
+	rc.bucketCalls++
+	return rc.Client.Bucket(name)
+}
+
+// We do not need to implement methods that we don't want to record - by default
+// the embedded type will be used.
+
+func Example_recordBuckets() {
+	// This example demonstrates building a simple mock that the number of
+	// Bucket calls before calling the real client and returning its output.
+
+	ctx := context.Background()
+	c, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	client := stiface.AdaptClient(c)
+	recordingClient := RecordingClient{client, 0}
+
+	recordingClient.Bucket("my-bucket-1")
+	recordingClient.Bucket("my-bucket-2")
+	recordingClient.Bucket("my-bucket-3")
+
+	fmt.Println(recordingClient.bucketCalls)
+	// Output: 3
+}

--- a/storage/stiface/doc.go
+++ b/storage/stiface/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stiface provides a set of interfaces for the types in
+// cloud.google.com/go/storage. These can be used to create mocks or other test
+// doubles. The package also provides adapters to enable the types of the
+// storage package to implement these interfaces.
+//
+// We do not recommend using mocks for most testing. Please read
+// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+//
+// Note: This package is in alpha. Some backwards-incompatible changes may occur.
+//
+// You must embed these interfaces to implement them:
+//
+//    type ClientMock struct {
+//        stiface.Client
+//        ...
+//    }
+//
+// This ensures that your implementations will not break when methods are added
+// to the interfaces.
+package stiface

--- a/storage/stiface/examples_test.go
+++ b/storage/stiface/examples_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
 	"github.com/googleapis/google-cloud-go-testing/storage/stiface"
 )
 

--- a/storage/stiface/interfaces.go
+++ b/storage/stiface/interfaces.go
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package stiface provides a set of interfaces for the types in cloud.google.com/go/storage.
-// These can be used to create mocks or other test doubles.
-// The package also provides adapters to enable the types of the storage package to
-// implement these interfaces.
-//
-// We do not recommend using mocks for most testing. Please read
-// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
-//
-// You must embed these interfaces to implement them:
-//
-//    type ClientMock struct {
-//        stiface.Client
-//        ...
-//    }
-//
-// This ensures that your implementations will not break when methods are added to the interfaces.
 package stiface
 
 import (


### PR DESCRIPTION
Additionally:

- Moves all package documentation to doc.go files
- Adds alpha notes to all package documentation

Fixes #9