### PR TITLE
pubsub: adds basic support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ Guidelines](https://opensource.google.com/conduct/).
 
 ## Testing
 
+### storage/psiface
+
+Before running the tests, set the PSIFACE_TOPIC environment variable to the
+name of a topic for which you have publish permissions and the ability to
+create, consume and delete subscriptions.
+
 ### storage/stiface
 
 Before running the tests, set the STIFACE_BUCKET environment variable to the

--- a/pubsub/psiface/adapters.go
+++ b/pubsub/psiface/adapters.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package psiface
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+)
+
+// AdaptClient adapts a pubsub.Client so that it satisfies the Client
+// interface.
+func AdaptClient(c *pubsub.Client) Client {
+	return client{c}
+}
+
+type (
+	client        struct{ *pubsub.Client }
+	topic         struct{ *pubsub.Topic }
+	subscription  struct{ *pubsub.Subscription }
+	publishResult struct{ *pubsub.PublishResult }
+)
+
+func (client) embedToIncludeNewMethods()        {}
+func (topic) embedToIncludeNewMethods()         {}
+func (subscription) embedToIncludeNewMethods()  {}
+func (publishResult) embedToIncludeNewMethods() {}
+
+func (c client) CreateTopic(ctx context.Context, topicID string) (Topic, error) {
+	t, err := c.Client.CreateTopic(ctx, topicID)
+	if err != nil {
+		return nil, err
+	}
+	return topic{t}, nil
+}
+
+func (c client) Topic(id string) Topic {
+	return topic{c.Client.Topic(id)}
+}
+
+func (c client) CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error) {
+	s, err := c.Client.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
+		Topic: c.Client.Topic(topicID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return subscription{s}, nil
+}
+
+func (c client) Subscription(id string) Subscription {
+	return subscription{c.Client.Subscription(id)}
+}
+
+func (t topic) String() string {
+	return t.Topic.String()
+}
+
+func (t topic) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
+	return publishResult{t.Topic.Publish(ctx, msg)}
+}
+
+func (s subscription) Exists(ctx context.Context) (bool, error) {
+	return s.Subscription.Exists(ctx)
+}
+
+func (s subscription) Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error {
+	return s.Subscription.Receive(ctx, f)
+}
+
+func (s subscription) Delete(ctx context.Context) error {
+	return s.Subscription.Delete(ctx)
+}
+
+func (r publishResult) Get(ctx context.Context) (serverID string, err error) {
+	return r.PublishResult.Get(ctx)
+}

--- a/pubsub/psiface/adapters.go
+++ b/pubsub/psiface/adapters.go
@@ -50,10 +50,8 @@ func (c client) Topic(id string) Topic {
 	return topic{c.Client.Topic(id)}
 }
 
-func (c client) CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error) {
-	s, err := c.Client.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
-		Topic: c.Client.Topic(topicID),
-	})
+func (c client) CreateSubscription(ctx context.Context, id string, cfg SubscriptionConfig) (Subscription, error) {
+	s, err := c.Client.CreateSubscription(ctx, id, cfg.toPS())
 	if err != nil {
 		return nil, err
 	}
@@ -86,4 +84,15 @@ func (s subscription) Delete(ctx context.Context) error {
 
 func (r publishResult) Get(ctx context.Context) (serverID string, err error) {
 	return r.PublishResult.Get(ctx)
+}
+
+func (cfg SubscriptionConfig) toPS() pubsub.SubscriptionConfig {
+	return pubsub.SubscriptionConfig{
+		Topic:               cfg.Topic.(topic).Topic,
+		PushConfig:          cfg.PushConfig,
+		AckDeadline:         cfg.AckDeadline,
+		RetainAckedMessages: cfg.RetainAckedMessages,
+		RetentionDuration:   cfg.RetentionDuration,
+		Labels:              cfg.Labels,
+	}
 }

--- a/pubsub/psiface/doc.go
+++ b/pubsub/psiface/doc.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package psiface provides a set of interfaces for the types in
+// cloud.google.com/go/pubsub. These can be used to create mocks or other test
+// doubles. The package also provides adapters to enable the types of the
+// pubsub package to implement these interfaces.
+//
+// We do not recommend using mocks for most testing. Please read
+// https://testing.googleblog.com/2013/05/testing-on-toilet-dont-overuse-mocks.html.
+//
+// Note: This package is in alpha. Some backwards-incompatible changes may occur.
+//
+// You must embed these interfaces to implement them:
+//
+//    type ClientMock struct {
+//        psiface.Client
+//        ...
+//    }
+//
+// This ensures that your implementations will not break when methods are added
+// to the interfaces.
+package psiface

--- a/pubsub/psiface/examples_test.go
+++ b/pubsub/psiface/examples_test.go
@@ -21,14 +21,14 @@ import (
 	"github.com/googleapis/google-cloud-go-testing/pubsub/psiface"
 )
 
-func Example_AdaptClient() {
+func ExampleAdaptClient() {
 	ctx := context.Background()
 	c, err := pubsub.NewClient(ctx, "")
 	if err != nil {
 		// TODO: Handle error.
 	}
 	client := psiface.AdaptClient(c)
-	msg := &pubsub.Message{}
+	msg := psiface.AdaptMessage(&pubsub.Message{})
 	_, err = client.Topic("my-topic").Publish(ctx, msg).Get(ctx)
 	if err != nil {
 		// TODO: Handle error.

--- a/pubsub/psiface/examples_test.go
+++ b/pubsub/psiface/examples_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package psiface_test
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/googleapis/google-cloud-go-testing/pubsub/psiface"
+)
+
+func Example_AdaptClient() {
+	ctx := context.Background()
+	c, err := pubsub.NewClient(ctx, "")
+	if err != nil {
+		// TODO: Handle error.
+	}
+	client := psiface.AdaptClient(c)
+	msg := &pubsub.Message{}
+	_, err = client.Topic("my-topic").Publish(ctx, msg).Get(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}

--- a/pubsub/psiface/interfaces.go
+++ b/pubsub/psiface/interfaces.go
@@ -16,8 +16,7 @@ package psiface
 
 import (
 	"context"
-
-	"cloud.google.com/go/pubsub"
+	"time"
 )
 
 type Client interface {
@@ -31,15 +30,26 @@ type Client interface {
 
 type Topic interface {
 	String() string
-	Publish(ctx context.Context, msg *pubsub.Message) PublishResult
+	Publish(ctx context.Context, msg Message) PublishResult
 
 	embedToIncludeNewMethods()
 }
 
 type Subscription interface {
 	Exists(ctx context.Context) (bool, error)
-	Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error
+	Receive(ctx context.Context, f func(context.Context, Message)) error
 	Delete(ctx context.Context) error
+
+	embedToIncludeNewMethods()
+}
+
+type Message interface {
+	ID() string
+	Data() []byte
+	Attributes() map[string]string
+	PublishTime() time.Time
+	Ack()
+	Nack()
 
 	embedToIncludeNewMethods()
 }

--- a/pubsub/psiface/interfaces.go
+++ b/pubsub/psiface/interfaces.go
@@ -23,7 +23,7 @@ import (
 type Client interface {
 	CreateTopic(ctx context.Context, topicID string) (Topic, error)
 	Topic(id string) Topic
-	CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error)
+	CreateSubscription(ctx context.Context, id string, cfg SubscriptionConfig) (Subscription, error)
 	Subscription(id string) Subscription
 
 	embedToIncludeNewMethods()

--- a/pubsub/psiface/interfaces.go
+++ b/pubsub/psiface/interfaces.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package psiface
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+)
+
+type Client interface {
+	CreateTopic(ctx context.Context, topicID string) (Topic, error)
+	Topic(id string) Topic
+	CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error)
+	Subscription(id string) Subscription
+
+	embedToIncludeNewMethods()
+}
+
+type Topic interface {
+	String() string
+	Publish(ctx context.Context, msg *pubsub.Message) PublishResult
+
+	embedToIncludeNewMethods()
+}
+
+type Subscription interface {
+	Exists(ctx context.Context) (bool, error)
+	Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error
+	Delete(ctx context.Context) error
+
+	embedToIncludeNewMethods()
+}
+
+type PublishResult interface {
+	Get(ctx context.Context) (serverID string, err error)
+
+	embedToIncludeNewMethods()
+}

--- a/pubsub/psiface/psiface_test.go
+++ b/pubsub/psiface/psiface_test.go
@@ -1,0 +1,223 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package psiface
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+)
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration tests skipped in short mode")
+	}
+
+	topicID := os.Getenv("PSIFACE_TOPIC")
+	if topicID == "" {
+		t.Skip("missing PSIFACE_TOPIC environment variable")
+	}
+	projID, topicName, err := parseTopic(topicID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subscriptionName := fmt.Sprintf("psiface_test_%d", time.Now().UnixNano())
+	ctx := context.Background()
+	c, err := pubsub.NewClient(ctx, projID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := AdaptClient(c)
+	basicTests(t, topicName, subscriptionName, client)
+}
+
+func basicTests(t *testing.T, topicName string, subscriptionName string, client Client) {
+	ctx := context.Background()
+	topic := client.Topic(topicName)
+
+	sub, err := client.CreateSubscription(ctx, subscriptionName, topicName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const contents = "hello, psiface"
+	ctx, cancel := context.WithCancel(ctx)
+	errs := make(chan error, 50)
+	go func() {
+		err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+			got, want := string(msg.Data), contents
+			msg.Ack()
+			if got == want {
+				errs <- nil
+				cancel()
+			}
+		})
+		if err != nil {
+			errs <- err
+		}
+	}()
+
+	_, err = topic.Publish(ctx, &pubsub.Message{Data: []byte(contents)}).Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = <-errs
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx = context.Background()
+	err = sub.Delete(ctx)
+	if err != nil {
+		t.Errorf("deleting: %v", err)
+	}
+}
+
+func parseTopic(topicID string) (project, topic string, err error) {
+	segs := strings.Split(topicID, "/")
+	if len(segs) != 4 || segs[0] != "projects" || segs[2] != "topics" {
+		return "", "", errors.New("invalid topic id")
+	}
+	return segs[1], segs[3], nil
+}
+
+// This test demonstrates how to use this package to create a simple fake for the pubsub client.
+func TestFake(t *testing.T) {
+	ctx := context.Background()
+	client := newFakeClient()
+	if _, err := client.CreateTopic(ctx, "my-topic"); err != nil {
+		t.Fatal(err)
+	}
+	basicTests(t, "my-topic", "my-subscription", client)
+}
+
+type fakeClient struct {
+	Client
+	topics sync.Map
+	subs   sync.Map
+}
+
+func newFakeClient() Client {
+	return &fakeClient{}
+}
+
+func (c *fakeClient) CreateTopic(_ context.Context, topicID string) (Topic, error) {
+	if _, ok := c.topics.Load(topicID); ok {
+		return nil, fmt.Errorf("topic %q already exists", topicID)
+	}
+	t := &fakeTopic{c: c, name: topicID}
+	c.topics.Store(topicID, t)
+	return t, nil
+}
+
+func (c *fakeClient) Topic(id string) Topic {
+	t, ok := c.topics.Load(id)
+	if !ok {
+		return &fakeTopic{c: c, name: id}
+	}
+	return t.(Topic)
+}
+
+func (c *fakeClient) CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error) {
+	if _, ok := c.subs.Load(id); ok {
+		return nil, fmt.Errorf("subscription %q already exists", id)
+	}
+	s := &fakeSubscription{
+		c:       c,
+		name:    id,
+		topicID: topicID,
+		msgs:    make(chan *pubsub.Message, 50),
+	}
+	c.subs.Store(id, s)
+	t := c.Topic(topicID).(*fakeTopic)
+	t.subs = append(t.subs, s)
+	return s, nil
+}
+
+func (c *fakeClient) Subscription(id string) Subscription {
+	t, ok := c.subs.Load(id)
+	if !ok {
+		return &fakeSubscription{c: c, name: id}
+	}
+	return t.(Subscription)
+}
+
+type fakeTopic struct {
+	Topic
+	c    *fakeClient
+	name string
+	subs []*fakeSubscription
+}
+
+func (t *fakeTopic) String() string {
+	return t.name
+}
+
+func (t *fakeTopic) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
+	for _, sub := range t.subs {
+		if sub.topicID == t.name {
+			sub.msgs <- msg
+		}
+	}
+	return &fakePublishResult{}
+}
+
+type fakeSubscription struct {
+	Subscription
+	c       *fakeClient
+	name    string
+	topicID string
+	msgs    chan *pubsub.Message
+}
+
+func (s *fakeSubscription) Exists(_ context.Context) (bool, error) {
+	_, ok := s.c.subs.Load(s.name)
+	return ok, nil
+}
+
+func (s *fakeSubscription) Receive(ctx context.Context, f func(context.Context, *pubsub.Message)) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg, ok := <-s.msgs:
+			if !ok {
+				return nil
+			}
+			f(ctx, msg)
+		}
+	}
+}
+
+func (s *fakeSubscription) Delete(_ context.Context) error {
+	s.c.subs.Delete(s.name)
+	return nil
+}
+
+type fakePublishResult struct {
+	PublishResult
+}
+
+func (r *fakePublishResult) Get(_ context.Context) (serverID string, err error) {
+	return "", nil
+}

--- a/pubsub/psiface/psiface_test.go
+++ b/pubsub/psiface/psiface_test.go
@@ -55,7 +55,7 @@ func basicTests(t *testing.T, topicName string, subscriptionName string, client 
 	ctx := context.Background()
 	topic := client.Topic(topicName)
 
-	sub, err := client.CreateSubscription(ctx, subscriptionName, topicName)
+	sub, err := client.CreateSubscription(ctx, subscriptionName, SubscriptionConfig{Topic: topic})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,8 @@ func parseTopic(topicID string) (project, topic string, err error) {
 	return segs[1], segs[3], nil
 }
 
-// This test demonstrates how to use this package to create a simple fake for the pubsub client.
+// This test demonstrates how to use this package to create a simple fake for
+// the pubsub client.
 func TestFake(t *testing.T) {
 	ctx := context.Background()
 	client := newFakeClient()
@@ -138,18 +139,18 @@ func (c *fakeClient) Topic(id string) Topic {
 	return t.(Topic)
 }
 
-func (c *fakeClient) CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error) {
+func (c *fakeClient) CreateSubscription(ctx context.Context, id string, cfg SubscriptionConfig) (Subscription, error) {
 	if _, ok := c.subs.Load(id); ok {
 		return nil, fmt.Errorf("subscription %q already exists", id)
 	}
 	s := &fakeSubscription{
 		c:       c,
 		name:    id,
-		topicID: topicID,
+		topicID: cfg.Topic.String(),
 		msgs:    make(chan *pubsub.Message, 50),
 	}
 	c.subs.Store(id, s)
-	t := c.Topic(topicID).(*fakeTopic)
+	t := cfg.Topic.(*fakeTopic)
 	t.subs = append(t.subs, s)
 	return s, nil
 }

--- a/pubsub/psiface/structs.go
+++ b/pubsub/psiface/structs.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package psiface
+
+import (
+	"cloud.google.com/go/pubsub"
+)
+
+type SubscriptionConfig struct {
+	pubsub.SubscriptionConfig
+	Topic Topic // shadows pubsub.SubscriptionConfig's field
+}


### PR DESCRIPTION
The part of this I'm least keen on is the change of signature in the adapter, from:

```golang
func (c *Client) CreateSubscription(ctx context.Context, id string, cfg SubscriptionConfig) (*Subscription, error)
```

to:

```golang
func (c client) CreateSubscription(ctx context.Context, id string, topicID string) (Subscription, error)
```

The problem is that the `SubscriptionConfig` struct contains a reference to a `pubsub.Topic` struct. I'm open to improving this if there are any ideas: taking just the name of the topic sufficed for my basic needs.