### PR TITLE
internal: drop support for 1.9 and 1.10

### DIFF
--- a/internal/kokoro/test.sh
+++ b/internal/kokoro/test.sh
@@ -17,6 +17,7 @@ go version
 export GOPATH="$HOME/go"
 export GCGT_HOME=$GOPATH/src/github.com/googleapis/google-cloud-go-testing
 export PATH="$GOPATH/bin:$PATH"
+export GO111MODULE=on
 mkdir -p $GCGT_HOME
 
 # Move code into $GOPATH and get dependencies
@@ -25,19 +26,8 @@ cd $GCGT_HOME
 
 try3() { eval "$*" || eval "$*" || eval "$*"; }
 
-download_deps() {
-    if [[ `go version` == *"go1.11"* ]] || [[ `go version` == *"go1.12"* ]]; then
-        export GO111MODULE=on
-        # All packages, including +build tools, are fetched.
-        try3 go mod download
-    else
-        # Because we don't provide -tags tools, the +build tools
-        # dependencies aren't fetched.
-        try3 go get -v -t ./...
-    fi
-}
-
-download_deps
+# All packages, including +build tools, are fetched.
+try3 go mod download
 ./internal/kokoro/vet.sh
 
 # Run tests and tee output to log file, to be pushed to GCS as artifact.

--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Fail on any error
-set -eo pipefail
-
 # Display commands being run
 set -x
 
@@ -27,7 +24,7 @@ git diff go.sum | tee /dev/stderr | (! read)
 pwd
 
 # Look at all .go files (ignoring .pb.go files) and make sure they have a Copyright. Fail if any don't.
-git ls-files "*[^.pb].go" | xargs grep -L "\(Copyright [0-9]\{4,\}\)" 2>&1 | tee /dev/stderr | (! read)
+find . -type f -name "*.go" ! -name "*.pb.go" -exec grep -L "\(Copyright [0-9]\{4,\}\)" {} \; 2>&1 | tee /dev/stderr | (! read)
 gofmt -s -d -l . 2>&1 | tee /dev/stderr | (! read)
 goimports -l . 2>&1 | tee /dev/stderr | (! read)
 


### PR DESCRIPTION
As of Oct 1, 2019 GCP is no longer supporting Go 1.9 and 1.10.
Cleaning up build scripts to support this.