### PR TITLE
fix basicTests data race

### DIFF
--- a/pubsub/psiface/psiface_test.go
+++ b/pubsub/psiface/psiface_test.go
@@ -68,7 +68,7 @@ func basicTests(t *testing.T, msg Message, topicName string, subscriptionName st
 	ctx, cancel := context.WithCancel(ctx)
 	errs := make(chan error, 50)
 	go func() {
-		err = sub.Receive(ctx, func(ctx context.Context, msg Message) {
+		err := sub.Receive(ctx, func(ctx context.Context, msg Message) {
 			got, want := string(msg.Data()), contents
 			msg.Ack()
 			if got == want {


### PR DESCRIPTION
basicTests currently has a data race wherein inner and outer goroutine both can
set err. This CL changes the inner goroutine to use its own, locally-scoped err.